### PR TITLE
Harden TLS and SSH configurations

### DIFF
--- a/docs/cryptography.md
+++ b/docs/cryptography.md
@@ -1,0 +1,61 @@
+# Cryptography Guidelines
+
+This project prioritizes the use of proven, battle-hardened, and open-source cryptographic implementations. We avoid implementing custom cryptographic algorithms ("rolling your own crypto") and rely on the Go standard library and the extended `golang.org/x/crypto` packages.
+
+## Recommended Libraries
+
+For all cryptographic operations, use the following libraries:
+
+### Transport Layer Security (TLS)
+
+- **Library**: `crypto/tls` (Standard Library)
+- **Usage**: Secure communication between services and clients.
+- **Configuration**:
+  - Enforce `MinVersion: tls.VersionTLS12` (TLS 1.2 or higher).
+  - Use restricted `CipherSuites` prioritizing AEAD ciphers (GCM, ChaCha20-Poly1305).
+  - Avoid CBC mode ciphers.
+  - Use strict certificate verification.
+
+### Secure Shell (SSH)
+
+- **Library**: `golang.org/x/crypto/ssh`
+- **Usage**: Secure remote access and command execution.
+- **Configuration**:
+  - Use strict `HostKeyCallback` (e.g., `knownhosts` package).
+  - Restrict `KeyExchanges` to modern curves (Curve25519, NIST P-256/384/521).
+  - Restrict `Ciphers` to AEAD modes (ChaCha20-Poly1305, AES-GCM).
+  - Restrict `MACs` to HMAC-SHA2 (SHA-256/512) or EtM modes.
+
+### Hashing
+
+- **Library**: `crypto/sha256` or `crypto/sha512` (Standard Library)
+- **Usage**: Data integrity, checksums, identifiers.
+- **Note**: Do not use MD5 or SHA-1 for security purposes.
+
+### Password Hashing
+
+- **Library**: `golang.org/x/crypto/argon2`
+- **Usage**: Storing user passwords.
+- **Configuration**: Use recommended parameters for memory and time cost (e.g., Argon2id).
+
+### Symmetric Encryption
+
+- **Library**: `crypto/aes` with `crypto/cipher` (GCM mode) or `golang.org/x/crypto/chacha20poly1305`
+- **Usage**: Encrypting data at rest or specific fields.
+- **Note**: Always use authenticated encryption (AEAD).
+
+### Randomness
+
+- **Library**: `crypto/rand` (Standard Library)
+- **Usage**: Generating keys, nonces, salts, and tokens.
+- **Note**: Do not use `math/rand` for security-sensitive values.
+
+## Key Management
+
+- Keys should never be hardcoded in the source code.
+- Use environment variables or a dedicated secrets manager (e.g., HashiCorp Vault, AWS Secrets Manager) to inject keys at runtime.
+- In `internal/securecomms`, keys are accepted as PEM-encoded byte slices, allowing flexibility in how they are loaded.
+
+## Implementation Details
+
+The `internal/securecomms` package provides helper functions that adhere to these guidelines, enforcing strict defaults for TLS and SSH configurations.

--- a/docs/securecomms.md
+++ b/docs/securecomms.md
@@ -5,10 +5,12 @@ The `internal/securecomms` package provides helper functions to create secure TL
 ## TLS Configuration
 
 The package simplifies creating `tls.Config` objects for both clients and servers, enforcing TLS 1.2+ and proper certificate handling.
+It enforces a strict list of AEAD-based cipher suites for TLS 1.2 to ensure strong security.
 
 ### Client Configuration
 
 Use `NewTLSClientConfig` to create a `tls.Config` for a client. It supports mutual TLS (mTLS) if client certificates are provided.
+It also allows controlling whether to trust the system's root CAs via the `trustSystemCAs` parameter.
 
 ```go
 package main
@@ -38,6 +40,7 @@ func main() {
 		"server.example.com", // Expected ServerName
 		clientCertPEM,        // Optional: nil or empty if not using mTLS
 		clientKeyPEM,         // Optional: nil or empty if not using mTLS
+		false,                // trustSystemCAs: false (only trust provided CA)
 	)
 	if err != nil {
 		log.Fatalf("Failed to create TLS config: %v", err)
@@ -104,6 +107,7 @@ func main() {
 ## SSH Configuration
 
 The package provides `NewSSHClientConfig` to create a strict `ssh.ClientConfig` that validates host keys against a provided `known_hosts` data.
+It enforces a strict set of Ciphers, Key Exchanges, and MACs, prioritizing AEAD and modern elliptic curves.
 
 ### Client Configuration
 

--- a/internal/securecomms/ssh.go
+++ b/internal/securecomms/ssh.go
@@ -10,6 +10,37 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+// secureSSHCiphers lists preferred AEAD ciphers and strong CTR modes.
+// It avoids CBC modes which are vulnerable to padding oracle attacks.
+var secureSSHCiphers = []string{
+	"chacha20-poly1305@openssh.com",
+	"aes128-gcm@openssh.com",
+	"aes256-gcm@openssh.com",
+	"aes128-ctr",
+	"aes192-ctr",
+	"aes256-ctr",
+}
+
+// secureSSHKeyExchanges lists preferred key exchange algorithms, prioritizing
+// modern elliptic curves (Curve25519) and strong NIST curves.
+var secureSSHKeyExchanges = []string{
+	"curve25519-sha256",
+	"curve25519-sha256@libssh.org",
+	"ecdh-sha2-nistp256",
+	"ecdh-sha2-nistp384",
+	"ecdh-sha2-nistp521",
+	"diffie-hellman-group14-sha256",
+}
+
+// secureSSHMACs lists preferred message authentication code algorithms,
+// prioritizing Encrypt-then-MAC (EtM) modes and SHA-2.
+var secureSSHMACs = []string{
+	"hmac-sha2-256-etm@openssh.com",
+	"hmac-sha2-512-etm@openssh.com",
+	"hmac-sha2-256",
+	"hmac-sha2-512",
+}
+
 // NewSSHClientConfig builds a strict SSH client config using known_hosts validation.
 func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte) (*ssh.ClientConfig, error) {
 	if user == "" {
@@ -27,6 +58,10 @@ func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte
 		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
+	// We use a temporary file for known_hosts because the proven knownhosts package
+	// from golang.org/x/crypto/ssh/knownhosts only accepts file paths, not io.Reader.
+	// While suboptimal, using the battle-hardened parser is safer than implementing
+	// a custom one. We ensure the file is cleaned up.
 	tmpFile, err := os.CreateTemp("", "known_hosts_*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp known_hosts file: %w", err)
@@ -51,6 +86,11 @@ func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte
 	}
 
 	return &ssh.ClientConfig{
+		Config: ssh.Config{
+			Ciphers:      secureSSHCiphers,
+			KeyExchanges: secureSSHKeyExchanges,
+			MACs:         secureSSHMACs,
+		},
 		User:            user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: hostKeyCallback,

--- a/internal/securecomms/ssh_test.go
+++ b/internal/securecomms/ssh_test.go
@@ -17,10 +17,16 @@ func TestNewSSHClientConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateRSAPrivateKeyPEM: %v", err)
 	}
-	hostSigner, err := generateSSHSigner()
+
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		t.Fatalf("generateSSHSigner: %v", err)
+		t.Fatalf("rsa.GenerateKey: %v", err)
 	}
+	hostSigner, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("ssh.NewSignerFromKey: %v", err)
+	}
+
 	knownHostsLine := knownhosts.Line([]string{"example.com"}, hostSigner.PublicKey())
 
 	cfg, err := NewSSHClientConfig("alice", clientKeyPEM, []byte(knownHostsLine+"\n"))
@@ -33,6 +39,57 @@ func TestNewSSHClientConfig(t *testing.T) {
 	if len(cfg.Auth) == 0 {
 		t.Fatal("expected auth methods")
 	}
+
+	// Verify strict crypto settings
+	if len(cfg.Ciphers) == 0 {
+		t.Fatal("expected Ciphers to be set")
+	}
+	for _, c := range cfg.Ciphers {
+		found := false
+		for _, allowed := range secureSSHCiphers {
+			if c == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Cipher %q is not in the allowed list", c)
+		}
+	}
+
+	if len(cfg.KeyExchanges) == 0 {
+		t.Fatal("expected KeyExchanges to be set")
+	}
+	for _, k := range cfg.KeyExchanges {
+		found := false
+		for _, allowed := range secureSSHKeyExchanges {
+			if k == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("KeyExchange %q is not in the allowed list", k)
+		}
+	}
+
+	if len(cfg.MACs) == 0 {
+		t.Fatal("expected MACs to be set")
+	}
+	for _, m := range cfg.MACs {
+		found := false
+		for _, allowed := range secureSSHMACs {
+			if m == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("MAC %q is not in the allowed list", m)
+		}
+	}
+
+	// Verify HostKeyCallback works
 	if err := cfg.HostKeyCallback("example.com:22", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}, hostSigner.PublicKey()); err != nil {
 		t.Fatalf("expected host key callback success, got: %v", err)
 	}
@@ -46,6 +103,15 @@ func TestNewSSHClientConfigInvalidInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateRSAPrivateKeyPEM: %v", err)
 	}
+
+	// Assuming knownhosts.New fails on garbage input as per original test expectation
+	// Note: knownhosts parser is quite robust, so "not-known-hosts" might just be ignored as a comment or invalid line.
+	// But let's check if the original test relied on it failing.
+	// We'll keep it commented out if we are unsure, or rely on `knownHostsData` check inside NewSSHClientConfig which we added (len==0 check).
+	// But "not-known-hosts" is not empty.
+	// If the original test expected failure, then `knownhosts.New` MUST fail.
+	// Let's re-enable it to be safe and see if tests pass.
+	// However, if "not-known-hosts" is treated as a hostname without key, it's invalid format.
 	if _, err := NewSSHClientConfig("alice", keyPEM, []byte("not-known-hosts")); err == nil {
 		t.Fatal("expected error for invalid known_hosts data")
 	}
@@ -60,12 +126,4 @@ func generateRSAPrivateKeyPEM() ([]byte, error) {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(key),
 	}), nil
-}
-
-func generateSSHSigner() (ssh.Signer, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, err
-	}
-	return ssh.NewSignerFromKey(key)
 }

--- a/internal/securecomms/tls.go
+++ b/internal/securecomms/tls.go
@@ -7,16 +7,38 @@ import (
 	"fmt"
 )
 
+// secureCipherSuites is a list of strict, AEAD-based cipher suites for TLS 1.2.
+// TLS 1.3 cipher suites are not configurable and are secure by default.
+var secureCipherSuites = []uint16{
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
 // NewTLSClientConfig builds a secure client TLS config with optional mTLS certs.
-func NewTLSClientConfig(caPEM []byte, serverName string, clientCertPEM []byte, clientKeyPEM []byte) (*tls.Config, error) {
+// trustSystemCAs determines whether to include the system's root CAs in the trust pool.
+// If set to false, only the provided caPEM will be trusted.
+func NewTLSClientConfig(caPEM []byte, serverName string, clientCertPEM []byte, clientKeyPEM []byte, trustSystemCAs bool) (*tls.Config, error) {
 	if serverName == "" {
 		return nil, errors.New("serverName is required")
 	}
 
-	rootCAs, err := x509.SystemCertPool()
-	if err != nil || rootCAs == nil {
+	var rootCAs *x509.CertPool
+	var err error
+
+	if trustSystemCAs {
+		rootCAs, err = x509.SystemCertPool()
+		if err != nil || rootCAs == nil {
+			// Fallback if system pool fails or is unavailable (e.g. windows container without certs)
+			rootCAs = x509.NewCertPool()
+		}
+	} else {
 		rootCAs = x509.NewCertPool()
 	}
+
 	if len(caPEM) > 0 {
 		if ok := rootCAs.AppendCertsFromPEM(caPEM); !ok {
 			return nil, errors.New("failed to append CA PEM")
@@ -24,9 +46,10 @@ func NewTLSClientConfig(caPEM []byte, serverName string, clientCertPEM []byte, c
 	}
 
 	cfg := &tls.Config{
-		MinVersion: tls.VersionTLS12,
-		RootCAs:    rootCAs,
-		ServerName: serverName,
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: secureCipherSuites,
+		RootCAs:      rootCAs,
+		ServerName:   serverName,
 	}
 
 	if len(clientCertPEM) > 0 || len(clientKeyPEM) > 0 {
@@ -55,6 +78,7 @@ func NewTLSServerConfig(serverCertPEM []byte, serverKeyPEM []byte, clientCAPEM [
 
 	cfg := &tls.Config{
 		MinVersion:   tls.VersionTLS12,
+		CipherSuites: secureCipherSuites,
 		Certificates: []tls.Certificate{cert},
 	}
 

--- a/internal/securecomms/tls_test.go
+++ b/internal/securecomms/tls_test.go
@@ -18,7 +18,8 @@ func TestNewTLSClientConfig(t *testing.T) {
 		t.Fatalf("generateCA: %v", err)
 	}
 
-	cfg, err := NewTLSClientConfig(caPEM, "example.com", nil, nil)
+	// Test with trustSystemCAs = false
+	cfg, err := NewTLSClientConfig(caPEM, "example.com", nil, nil, false)
 	if err != nil {
 		t.Fatalf("NewTLSClientConfig returned error: %v", err)
 	}
@@ -31,13 +32,38 @@ func TestNewTLSClientConfig(t *testing.T) {
 	if cfg.RootCAs == nil {
 		t.Fatal("expected RootCAs to be set")
 	}
+	if len(cfg.CipherSuites) == 0 {
+		t.Fatal("expected CipherSuites to be set")
+	}
+	// Verify strict cipher suites
+	for _, cs := range cfg.CipherSuites {
+		found := false
+		for _, allowed := range secureCipherSuites {
+			if cs == allowed {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("CipherSuite %d is not in the allowed list", cs)
+		}
+	}
+
+	// Test with trustSystemCAs = true (should not error, but harder to verify impact without actual system roots)
+	cfg2, err := NewTLSClientConfig(caPEM, "example.com", nil, nil, true)
+	if err != nil {
+		t.Fatalf("NewTLSClientConfig(trustSystemCAs=true) returned error: %v", err)
+	}
+	if cfg2.RootCAs == nil {
+		t.Fatal("expected RootCAs to be set")
+	}
 }
 
 func TestNewTLSClientConfigInvalidInput(t *testing.T) {
-	if _, err := NewTLSClientConfig([]byte("bad"), "example.com", nil, nil); err == nil {
+	if _, err := NewTLSClientConfig([]byte("bad"), "example.com", nil, nil, false); err == nil {
 		t.Fatal("expected error for invalid CA PEM")
 	}
-	if _, err := NewTLSClientConfig(nil, "", nil, nil); err == nil {
+	if _, err := NewTLSClientConfig(nil, "", nil, nil, false); err == nil {
 		t.Fatal("expected error for empty serverName")
 	}
 }
@@ -61,6 +87,9 @@ func TestNewTLSServerConfigMutualTLS(t *testing.T) {
 	}
 	if cfg.ClientCAs == nil {
 		t.Fatal("expected ClientCAs to be set")
+	}
+	if len(cfg.CipherSuites) == 0 {
+		t.Fatal("expected CipherSuites to be set")
 	}
 }
 


### PR DESCRIPTION
This PR hardens the cryptographic configurations in `internal/securecomms` by enforcing strict defaults for TLS and SSH.

It introduces a new `trustSystemCAs` parameter to `NewTLSClientConfig` to allow restricting trust to only the provided CA.
It also restricts TLS cipher suites to AEAD-based ones (GCM, ChaCha20-Poly1305) and SSH primitives to modern, secure algorithms (Curve25519, EtM MACs).

Additionally, it adds `docs/cryptography.md` to serve as a guideline for cryptographic best practices in the project.

---
*PR created automatically by Jules for task [5931078976027125224](https://jules.google.com/task/5931078976027125224) started by @mark-e-deyoung*