### PR TITLE
Support arbitrary build targets and WBAB compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,16 @@ Images published on release:
 ./scripts/gg test
 ./scripts/gg build linux amd64
 ./scripts/gg build windows amd64
+./scripts/gg build windows 386
 ```
 
 Outputs land in `dist/<goos>-<goarch>/`.
+
+## WBAB Compatibility
+
+This project is fully compatible with [WineBotAppBuilder (WBAB)](https://github.com/SemperSupra/WineBotAppBuilder) workflows.
+It produces artifacts in the standard `dist/` directory, making it suitable for inclusion in WBAB pipelines for packaging and distribution.
+The `scripts/gg` toolchain adheres to containerized build principles, ensuring deterministic outputs across environments.
 
 ## Development Commands
 
@@ -65,9 +72,11 @@ The `./scripts/gg` entrypoint supports the following stages:
 | `lint` | Run linter (`golangci-lint`) |
 | `vuln` | Run vulnerability check (`govulncheck`) |
 | `test` | Run tests |
+| `targets` | List supported build targets |
 | `build <goos> <goarch>` | Build binary for target OS/Arch |
 | `package` | Package artifacts (create checksums) |
 | `images` | Build local Docker images |
+| `smoke-windows [goarch]` | Run Windows binary in Wine (default: amd64) |
 
 ## VS Code Dev Container
 

--- a/scripts/gg
+++ b/scripts/gg
@@ -122,10 +122,14 @@ case "$stage" in
     echo "[gg] building dev image: $DEV_IMAGE" >&2
     docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
     ;;
+  targets)
+    run "$DEV_IMAGE" 'go tool dist list'
+    ;;
   smoke-windows)
-    exe="dist/windows-amd64/supragoflow.exe"
+    goarch="${1:-amd64}"
+    exe="dist/windows-${goarch}/supragoflow.exe"
     if [[ ! -f "$exe" ]]; then
-      echo "binary not found: $exe (run 'gg build windows amd64' first)" >&2
+      echo "binary not found: $exe (run 'gg build windows ${goarch}' first)" >&2
       exit 1
     fi
     # We must run with direct volume mount and entrypoint
@@ -147,10 +151,11 @@ stages:
   lint
   vuln
   test
+  targets
   build <goos> <goarch>
   package
   images   (build local images on host)
-  smoke-windows
+  smoke-windows [goarch]
 USAGE
     exit 2
     ;;


### PR DESCRIPTION
Updated build tooling to support specifying any Go-supported target OS/architecture, specifically enabling verification of Windows 32-bit builds, and documented compatibility with WineBotAppBuilder (WBAB) workflows.

---
*PR created automatically by Jules for task [14004634127139341405](https://jules.google.com/task/14004634127139341405) started by @mark-e-deyoung*