### PR TITLE
Add schema versioning for machine-readable outputs

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -42,6 +42,7 @@ Typical gates for incremental development:
 
 - `scripts/gg` supports tunable logging with `--log-level` (`debug|info|warn|error|none`) and `--log-format` (`text|json`).
 - Each `gg` invocation includes a run correlation id (`--run-id` or auto-generated) in log messages.
+- JSON log output includes `logSchemaVersion` for compatibility-aware consumers.
 - Informational diagnostics should be bounded; avoid repeating non-actionable messages across stages.
 
 ## Builds (build image)
@@ -51,6 +52,11 @@ Typical gates for incremental development:
 - `-trimpath`
 - `CGO_ENABLED=0` by default
 - Optional semantic naming via `--output-template` with tokens `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.
+
+## Machine-readable output compatibility
+
+- `supragoflow --version --json` includes `schemaVersion`.
+- Consumers should treat `schemaVersion` changes as contract changes requiring compatibility review.
 
 ## Security library/framework selection
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The `./scripts/gg` entrypoint supports the following stages:
 | `smoke-windows [goarch]` | Run Windows binary in Wine (default: amd64) |
 
 Global `gg` logging options (place before stage): `--log-level <debug|info|warn|error|none>`, `--log-format <text|json>`, `--run-id <id>`.
+When `--log-format json` is used, logs include `logSchemaVersion` and `run_id` fields.
 
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
 
@@ -95,6 +96,8 @@ Example:
 ```bash
 SUPRAGOFLOW_BUILD_VERSION=v1.2.3 ./scripts/gg build windows amd64 --output-template '{name}-{version}-{os}-{arch}{ext}'
 ```
+
+`supragoflow --version --json` emits machine-readable build metadata with `schemaVersion`.
 
 ## VS Code Dev Container
 

--- a/cmd/supragoflow/main_test.go
+++ b/cmd/supragoflow/main_test.go
@@ -80,9 +80,12 @@ func TestRunVersionJSON(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("invalid JSON output: %v\noutput: %q", err, out.String())
 	}
-	for _, key := range []string{"version", "commit", "date", "builtBy"} {
+	for _, key := range []string{"schemaVersion", "version", "commit", "date", "builtBy"} {
 		if _, ok := payload[key]; !ok {
 			t.Fatalf("missing key %q in JSON output: %v", key, payload)
 		}
+	}
+	if payload["schemaVersion"] != "1" {
+		t.Fatalf("unexpected schemaVersion %q", payload["schemaVersion"])
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -3,24 +3,27 @@ package version
 // These variables are intended to be set at build time via -ldflags.
 // Defaults keep local development simple.
 var (
-	Version = "dev"
-	Commit  = "none"
-	Date    = "unknown"
-	BuiltBy = "unknown"
+	SchemaVersion = "1"
+	Version       = "dev"
+	Commit        = "none"
+	Date          = "unknown"
+	BuiltBy       = "unknown"
 )
 
 type BuildInfo struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
-	Date    string `json:"date"`
-	BuiltBy string `json:"builtBy"`
+	SchemaVersion string `json:"schemaVersion"`
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	Date          string `json:"date"`
+	BuiltBy       string `json:"builtBy"`
 }
 
 func Info() BuildInfo {
 	return BuildInfo{
-		Version: Version,
-		Commit:  Commit,
-		Date:    Date,
-		BuiltBy: BuiltBy,
+		SchemaVersion: SchemaVersion,
+		Version:       Version,
+		Commit:        Commit,
+		Date:          Date,
+		BuiltBy:       BuiltBy,
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -4,6 +4,9 @@ import "testing"
 
 func TestInfo(t *testing.T) {
 	i := Info()
+	if i.SchemaVersion == "" {
+		t.Fatal("expected SchemaVersion to be non-empty")
+	}
 	if i.Version == "" {
 		t.Fatal("expected Version to be non-empty")
 	}

--- a/scripts/gg
+++ b/scripts/gg
@@ -12,6 +12,7 @@ LOG_LEVEL="${SUPRAGOFLOW_LOG_LEVEL:-info}"
 LOG_FORMAT="${SUPRAGOFLOW_LOG_FORMAT:-text}"
 RUN_ID="${SUPRAGOFLOW_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 REMOTE_PULL_DISABLED_NOTIFIED=0
+LOG_SCHEMA_VERSION="1"
 
 BUILD_ARGS=(
   --build-arg GO_VERSION="${GO_VERSION:-1.25.7}"
@@ -85,7 +86,8 @@ log_msg() {
   local ts
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   if [[ "$LOG_FORMAT" == "json" ]]; then
-    printf '{"ts":"%s","run_id":"%s","component":"gg","level":"%s","msg":"%s"}\n' \
+    printf '{"logSchemaVersion":"%s","ts":"%s","run_id":"%s","component":"gg","level":"%s","msg":"%s"}\n' \
+      "$(json_escape "$LOG_SCHEMA_VERSION")" \
       "$(json_escape "$ts")" \
       "$(json_escape "$RUN_ID")" \
       "$(json_escape "$level")" \

--- a/scripts/test-output-template.sh
+++ b/scripts/test-output-template.sh
@@ -68,4 +68,9 @@ run_and_capture out status env SUPRAGOFLOW_BUILD_VERSION=v1.2.3 "$GG" build linu
 [[ "$status" -eq 2 ]] || fail "unknown build option should exit with status 2"
 assert_contains "$out" "unknown build option" "unknown option validation message"
 
+run_and_capture out status env SUPRAGOFLOW_BUILD_VERSION=v1.2.3 "$GG" --log-format json --log-level debug build linux amd64 --print-output-name
+[[ "$status" -eq 0 ]] || fail "json logging self-test run should succeed"
+assert_contains "$out" "\"logSchemaVersion\":\"1\"" "json log schema version"
+assert_contains "$out" "\"run_id\":\"" "json log run id field"
+
 echo "output-template tests passed"


### PR DESCRIPTION
## Summary
Adds explicit schema versioning to machine-consumed outputs and log streams to preserve operational correctness under iterative changes.

### Implemented
- Add `schemaVersion` to `supragoflow --version --json` output.
- Add `logSchemaVersion` to `gg` JSON log output.
- Extend tests to lock schema fields and expected values.
- Update README/POLICY with compatibility guidance for machine-readable outputs.

## Contract impact
- CLI JSON consumers can now gate compatibility via `schemaVersion`.
- `gg` JSON log consumers can now gate compatibility via `logSchemaVersion`.

## Related backlog
- Refs #19 for broader `gg` interface-version contract/manifest governance.

## Validation
- `./scripts/gg self-test`
- `./scripts/gg test`
- `./scripts/gg --log-format json --log-level debug build linux amd64 --print-output-name`
