### PR TITLE
Harden lifecycle transitions and build metadata determinism

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -52,6 +52,7 @@ Typical gates for incremental development:
 - `-trimpath`
 - `CGO_ENABLED=0` by default
 - Optional semantic naming via `--output-template` with tokens `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.
+- Reproducible build metadata is supported via `SUPRAGOFLOW_BUILD_DATE` (fixed RFC3339 UTC timestamp).
 
 ## Machine-readable output compatibility
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ When `--log-format json` is used, logs include `logSchemaVersion` and `run_id` f
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
 
 `build` supports semantic artifact naming templates with tokens: `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.
+For reproducible metadata, `SUPRAGOFLOW_BUILD_DATE` can be set to a fixed RFC3339 UTC timestamp used for embedded build date.
 Example:
 
 ```bash

--- a/cmd/supragoflow/main.go
+++ b/cmd/supragoflow/main.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"io"
@@ -9,6 +13,7 @@ import (
 
 	"github.com/SemperSupra/supragoflow/internal/securecomms"
 	"github.com/SemperSupra/supragoflow/internal/version"
+	"golang.org/x/crypto/ssh"
 )
 
 func main() {
@@ -39,8 +44,7 @@ func run(args []string, out io.Writer) error {
 	case "check-ssh":
 		return handleCheckSSH(subArgs, out)
 	default:
-		// Fallback for flag-style version check if it's not the first arg (less common)
-		return handleVersion(args, out)
+		return fmt.Errorf("unknown subcommand: %s", subcommand)
 	}
 }
 
@@ -85,19 +89,37 @@ func handleCheckTLS(args []string, out io.Writer) error {
 
 func handleCheckSSH(args []string, out io.Writer) error {
 	_, _ = fmt.Fprintln(out, "Checking SSH configuration builder...")
-	// We need a dummy private key and known_hosts entry
-	// This is just to exercise the code path on the target OS (especially Wine).
-	// Using a real-looking but dummy RSA key.
-	dummyKey := []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA759I9... (dummy)\n-----END RSA PRIVATE KEY-----")
-	// The SSH builder validates the key format, so this will likely fail parsing.
-	// That's acceptable for a basic initialization check, but a real key would be better.
-	// For now, let's just confirm the code paths are reachable.
-	_, err := securecomms.NewSSHClientConfig("user", dummyKey, []byte("example.com ssh-rsa AAAAB3..."))
+	privateKeyPEM, knownHostsData, err := generateSmokeSSHMaterial()
 	if err != nil {
-		// We expect a parsing error, but not a system crash or library missing error.
-		_, _ = fmt.Fprintf(out, "Note: SSH config builder returned expected error (due to dummy data): %v\n", err)
-		return nil
+		return fmt.Errorf("failed to generate SSH smoke material: %w", err)
+	}
+	_, err = securecomms.NewSSHClientConfig("user", privateKeyPEM, knownHostsData)
+	if err != nil {
+		return fmt.Errorf("SSH client config failed: %w", err)
 	}
 	_, _ = fmt.Fprintln(out, "OK: SSH client config builder initialized successfully.")
 	return nil
+}
+
+func generateSmokeSSHMaterial() ([]byte, []byte, error) {
+	userKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate user key: %w", err)
+	}
+	userKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(userKey),
+	})
+
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate host key: %w", err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("host signer: %w", err)
+	}
+	knownHosts := []byte("example.com " + string(ssh.MarshalAuthorizedKey(hostSigner.PublicKey())))
+
+	return userKeyPEM, knownHosts, nil
 }

--- a/cmd/supragoflow/main_test.go
+++ b/cmd/supragoflow/main_test.go
@@ -50,9 +50,19 @@ func TestRunCheckSSH(t *testing.T) {
 	}
 
 	got := out.String()
-	if !strings.Contains(got, "OK: SSH client config builder initialized successfully.") &&
-		!strings.Contains(got, "Note: SSH config builder returned expected error") {
+	if !strings.Contains(got, "OK: SSH client config builder initialized successfully.") {
 		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRunUnknownSubcommand(t *testing.T) {
+	var out bytes.Buffer
+	err := run([]string{"unknown-subcommand"}, &out)
+	if err == nil {
+		t.Fatal("expected error for unknown subcommand")
+	}
+	if !strings.Contains(err.Error(), "unknown subcommand") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/scripts/gg
+++ b/scripts/gg
@@ -28,6 +28,7 @@ IMAGE_TAG="${SUPRAGOFLOW_IMAGE_TAG:-}"
 WINE_IMAGE="${SUPRAGOFLOW_WINE_RUNNER_IMAGE:-}"
 DEFAULT_OUTPUT_TEMPLATE="${SUPRAGOFLOW_OUTPUT_TEMPLATE:-}"
 DEFAULT_BUILD_VERSION="${SUPRAGOFLOW_BUILD_VERSION:-dev-local}"
+DEFAULT_BUILD_DATE="${SUPRAGOFLOW_BUILD_DATE:-}"
 if [[ -z "$DEFAULT_OUTPUT_TEMPLATE" ]]; then
   DEFAULT_OUTPUT_TEMPLATE='{name}{ext}'
 fi
@@ -269,8 +270,12 @@ case "$stage" in
     ext=""
     output_template="$DEFAULT_OUTPUT_TEMPLATE"
     build_version="$DEFAULT_BUILD_VERSION"
+    build_date="$DEFAULT_BUILD_DATE"
     print_output_name=0
     if [[ "$goos" == "windows" ]]; then ext=".exe"; fi
+    if [[ -z "$build_date" ]]; then
+      build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    fi
 
     while [[ $# -gt 0 ]]; do
       case "$1" in
@@ -300,7 +305,7 @@ case "$stage" in
     fi
     out="dist/${goos}-${goarch}"
     # Embed simple version info for local builds
-    run "$BUILD_IMAGE" "mkdir -p ${out} && CGO_ENABLED=0 GOOS=${goos} GOARCH=${goarch} go build -buildvcs=false -trimpath -ldflags='-s -w -X github.com/SemperSupra/supragoflow/internal/version.Version=${build_version} -X github.com/SemperSupra/supragoflow/internal/version.Commit=local -X github.com/SemperSupra/supragoflow/internal/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ) -X github.com/SemperSupra/supragoflow/internal/version.BuiltBy=gg' -o ${out}/${artifact_name} ./cmd/supragoflow"
+    run "$BUILD_IMAGE" "mkdir -p ${out} && CGO_ENABLED=0 GOOS=${goos} GOARCH=${goarch} go build -buildvcs=false -trimpath -ldflags='-s -w -X github.com/SemperSupra/supragoflow/internal/version.Version=${build_version} -X github.com/SemperSupra/supragoflow/internal/version.Commit=local -X github.com/SemperSupra/supragoflow/internal/version.Date=${build_date} -X github.com/SemperSupra/supragoflow/internal/version.BuiltBy=gg' -o ${out}/${artifact_name} ./cmd/supragoflow"
     ;;
   package)
     run "$BUILD_IMAGE" "mkdir -p dist && cd dist && (command -v sha256sum >/dev/null && sha256sum -b */* > SHA256SUMS || true)"


### PR DESCRIPTION
## Summary
Hardens lifecycle/state transitions and idempotence characteristics for CLI + build flow.

### Implemented
- Unknown CLI subcommands now return explicit errors instead of falling through to version behavior.
- `check-ssh` smoke path now validates successful config creation with ephemeral valid key material.
- Build metadata idempotence improved by supporting deterministic `SUPRAGOFLOW_BUILD_DATE`.
- README/POLICY updated for reproducible build metadata behavior.

## Correctness impact
- Reduces unexpected state transitions in CLI lifecycle.
- Removes false-positive success path in SSH diagnostic flow.
- Enables reproducible build metadata when required for deterministic outputs.

## Deferred tracking
- Refs #21 (`[DEFER]` release tag immutability safeguards).
- Refs #22 (`[DEFER]` lifecycle transition contract tests).

## Validation
- `./scripts/gg fmt`
- `./scripts/gg self-test`
- `./scripts/gg test`
- `./scripts/gg lint`
