### PR TITLE
Add runtime bounds, retries, and timeout configurability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   gates:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       GHCR_ORG: ${{ github.repository_owner }}
     steps:
@@ -55,6 +56,7 @@ jobs:
 
   windows_wine_smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: gates
     env:
       GHCR_ORG: ${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/POLICY.md
+++ b/POLICY.md
@@ -44,6 +44,7 @@ Typical gates for incremental development:
 - Each `gg` invocation includes a run correlation id (`--run-id` or auto-generated) in log messages.
 - JSON log output includes `logSchemaVersion` for compatibility-aware consumers.
 - Informational diagnostics should be bounded; avoid repeating non-actionable messages across stages.
+- Timeouts and pull retry/backoff are configurable to bound long-running operations (`SUPRAGOFLOW_TIMEOUT_*`, `SUPRAGOFLOW_PULL_RETRIES`, `SUPRAGOFLOW_PULL_BACKOFF_SEC`).
 
 ## Builds (build image)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ The `./scripts/gg` entrypoint supports the following stages:
 Global `gg` logging options (place before stage): `--log-level <debug|info|warn|error|none>`, `--log-format <text|json>`, `--run-id <id>`.
 When `--log-format json` is used, logs include `logSchemaVersion` and `run_id` fields.
 
+Runtime bounds are configurable with env vars, including:
+`SUPRAGOFLOW_TIMEOUT_STAGE_SEC`, `SUPRAGOFLOW_TIMEOUT_PULL_SEC`, `SUPRAGOFLOW_TIMEOUT_IMAGE_BUILD_SEC`, `SUPRAGOFLOW_TIMEOUT_SMOKE_SEC`, `SUPRAGOFLOW_PULL_RETRIES`, `SUPRAGOFLOW_PULL_BACKOFF_SEC`.
+
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
 
 `build` supports semantic artifact naming templates with tokens: `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.

--- a/internal/securecomms/ssh.go
+++ b/internal/securecomms/ssh.go
@@ -43,6 +43,12 @@ var secureSSHMACs = []string{
 
 // NewSSHClientConfig builds a strict SSH client config using known_hosts validation.
 func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte) (*ssh.ClientConfig, error) {
+	return NewSSHClientConfigWithTimeout(user, privateKeyPEM, knownHostsData, 10*time.Second)
+}
+
+// NewSSHClientConfigWithTimeout builds a strict SSH client config using
+// known_hosts validation and a caller-controlled connection timeout.
+func NewSSHClientConfigWithTimeout(user string, privateKeyPEM []byte, knownHostsData []byte, timeout time.Duration) (*ssh.ClientConfig, error) {
 	if user == "" {
 		return nil, errors.New("user is required")
 	}
@@ -51,6 +57,9 @@ func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte
 	}
 	if len(knownHostsData) == 0 {
 		return nil, errors.New("known_hosts data is required")
+	}
+	if timeout <= 0 {
+		return nil, errors.New("timeout must be > 0")
 	}
 
 	signer, err := ssh.ParsePrivateKey(privateKeyPEM)
@@ -94,6 +103,6 @@ func NewSSHClientConfig(user string, privateKeyPEM []byte, knownHostsData []byte
 		User:            user,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		HostKeyCallback: hostKeyCallback,
-		Timeout:         10 * time.Second,
+		Timeout:         timeout,
 	}, nil
 }

--- a/internal/securecomms/ssh_test.go
+++ b/internal/securecomms/ssh_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"net"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -92,6 +93,33 @@ func TestNewSSHClientConfig(t *testing.T) {
 	// Verify HostKeyCallback works
 	if err := cfg.HostKeyCallback("example.com:22", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}, hostSigner.PublicKey()); err != nil {
 		t.Fatalf("expected host key callback success, got: %v", err)
+	}
+}
+
+func TestNewSSHClientConfigWithTimeout(t *testing.T) {
+	clientKeyPEM, err := generateRSAPrivateKeyPEM()
+	if err != nil {
+		t.Fatalf("generateRSAPrivateKeyPEM: %v", err)
+	}
+	hostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("ssh.NewSignerFromKey: %v", err)
+	}
+	knownHostsLine := knownhosts.Line([]string{"example.com"}, hostSigner.PublicKey())
+
+	cfg, err := NewSSHClientConfigWithTimeout("alice", clientKeyPEM, []byte(knownHostsLine+"\n"), 3*time.Second)
+	if err != nil {
+		t.Fatalf("NewSSHClientConfigWithTimeout returned error: %v", err)
+	}
+	if cfg.Timeout != 3*time.Second {
+		t.Fatalf("unexpected timeout: %v", cfg.Timeout)
+	}
+	if _, err := NewSSHClientConfigWithTimeout("alice", clientKeyPEM, []byte(knownHostsLine+"\n"), 0); err == nil {
+		t.Fatal("expected error for non-positive timeout")
 	}
 }
 

--- a/scripts/gg
+++ b/scripts/gg
@@ -13,6 +13,12 @@ LOG_FORMAT="${SUPRAGOFLOW_LOG_FORMAT:-text}"
 RUN_ID="${SUPRAGOFLOW_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
 REMOTE_PULL_DISABLED_NOTIFIED=0
 LOG_SCHEMA_VERSION="1"
+PULL_RETRIES="${SUPRAGOFLOW_PULL_RETRIES:-3}"
+PULL_BACKOFF_SEC="${SUPRAGOFLOW_PULL_BACKOFF_SEC:-2}"
+TIMEOUT_STAGE_SEC="${SUPRAGOFLOW_TIMEOUT_STAGE_SEC:-1800}"
+TIMEOUT_PULL_SEC="${SUPRAGOFLOW_TIMEOUT_PULL_SEC:-300}"
+TIMEOUT_IMAGE_BUILD_SEC="${SUPRAGOFLOW_TIMEOUT_IMAGE_BUILD_SEC:-1800}"
+TIMEOUT_SMOKE_SEC="${SUPRAGOFLOW_TIMEOUT_SMOKE_SEC:-600}"
 
 BUILD_ARGS=(
   --build-arg GO_VERSION="${GO_VERSION:-1.25.7}"
@@ -36,6 +42,32 @@ fi
 # Named volumes for speed (safe for humans/agents)
 MODVOL="${SUPRAGOFLOW_MODVOL:-supragoflow-gomodcache}"
 CACHEVOL="${SUPRAGOFLOW_CACHEVOL:-supragoflow-gocache}"
+
+run_with_timeout() {
+  local timeout_sec="$1"; shift
+  if [[ "$timeout_sec" =~ ^[0-9]+$ ]] && [[ "$timeout_sec" -gt 0 ]] && command -v timeout >/dev/null 2>&1; then
+    timeout "${timeout_sec}s" "$@"
+  else
+    "$@"
+  fi
+}
+
+docker_pull_with_retry() {
+  local image_ref="$1"
+  local attempts="${PULL_RETRIES}"
+  local backoff="${PULL_BACKOFF_SEC}"
+  local i
+  for ((i=1; i<=attempts; i++)); do
+    if run_with_timeout "$TIMEOUT_PULL_SEC" docker pull "$image_ref" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [[ "$i" -lt "$attempts" ]]; then
+      log_msg warn "docker pull attempt ${i}/${attempts} failed for ${image_ref}; retrying in ${backoff}s"
+      sleep "$backoff"
+    fi
+  done
+  return 1
+}
 
 level_rank() {
   case "$1" in
@@ -124,7 +156,7 @@ pull_images() {
   local dev_remote="ghcr.io/$org/supragoflow-dev:$tag"
 
   if ! image_exists "$BUILD_IMAGE"; then
-    if docker pull "$build_remote" >/dev/null 2>&1; then
+    if docker_pull_with_retry "$build_remote"; then
       log_msg info "pulled build image from $build_remote"
       docker tag "$build_remote" "$BUILD_IMAGE"
     else
@@ -133,7 +165,7 @@ pull_images() {
   fi
 
   if ! image_exists "$DEV_IMAGE"; then
-    if docker pull "$dev_remote" >/dev/null 2>&1; then
+    if docker_pull_with_retry "$dev_remote"; then
       log_msg info "pulled dev image from $dev_remote"
       docker tag "$dev_remote" "$DEV_IMAGE"
     else
@@ -148,17 +180,17 @@ ensure_images() {
   # Build locally if missing (incremental bring-up friendly)
   if ! image_exists "$BUILD_IMAGE"; then
     log_msg info "building build image: $BUILD_IMAGE"
-    docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.build" -t "$BUILD_IMAGE" "$ROOT"
+    run_with_timeout "$TIMEOUT_IMAGE_BUILD_SEC" docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.build" -t "$BUILD_IMAGE" "$ROOT"
   fi
   if ! image_exists "$DEV_IMAGE"; then
     log_msg info "building dev image: $DEV_IMAGE"
-    docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
+    run_with_timeout "$TIMEOUT_IMAGE_BUILD_SEC" docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
   fi
 }
 
 run_in_image() {
   local image="$1"; shift
-  docker run --rm -t     -v "${ROOT}:${WORKDIR}" -w "${WORKDIR}"     -v "${CACHEVOL}:/go-cache"     -v "${MODVOL}:/go/pkg/mod"     -e GOCACHE=/go-cache     -e GOMODCACHE=/go/pkg/mod     -e GOPATH=/go     "$image" bash -c "$*"
+  run_with_timeout "$TIMEOUT_STAGE_SEC" docker run --rm -t     -v "${ROOT}:${WORKDIR}" -w "${WORKDIR}"     -v "${CACHEVOL}:/go-cache"     -v "${MODVOL}:/go/pkg/mod"     -e GOCACHE=/go-cache     -e GOMODCACHE=/go/pkg/mod     -e GOPATH=/go     "$image" bash -c "$*"
 }
 
 run() {
@@ -305,10 +337,10 @@ case "$stage" in
     fi
     out="dist/${goos}-${goarch}"
     # Embed simple version info for local builds
-    run "$BUILD_IMAGE" "mkdir -p ${out} && CGO_ENABLED=0 GOOS=${goos} GOARCH=${goarch} go build -buildvcs=false -trimpath -ldflags='-s -w -X github.com/SemperSupra/supragoflow/internal/version.Version=${build_version} -X github.com/SemperSupra/supragoflow/internal/version.Commit=local -X github.com/SemperSupra/supragoflow/internal/version.Date=${build_date} -X github.com/SemperSupra/supragoflow/internal/version.BuiltBy=gg' -o ${out}/${artifact_name} ./cmd/supragoflow"
+    run "$BUILD_IMAGE" "mkdir -p ${out} && tmp='${out}/.${artifact_name}.tmp.\$\$' && CGO_ENABLED=0 GOOS=${goos} GOARCH=${goarch} go build -buildvcs=false -trimpath -ldflags='-s -w -X github.com/SemperSupra/supragoflow/internal/version.Version=${build_version} -X github.com/SemperSupra/supragoflow/internal/version.Commit=local -X github.com/SemperSupra/supragoflow/internal/version.Date=${build_date} -X github.com/SemperSupra/supragoflow/internal/version.BuiltBy=gg' -o \"\${tmp}\" ./cmd/supragoflow && mv -f \"\${tmp}\" ${out}/${artifact_name}"
     ;;
   package)
-    run "$BUILD_IMAGE" "mkdir -p dist && cd dist && (command -v sha256sum >/dev/null && sha256sum -b */* > SHA256SUMS || true)"
+    run "$BUILD_IMAGE" "mkdir -p dist && cd dist && if command -v sha256sum >/dev/null; then tmp=.SHA256SUMS.tmp.\$\$; sha256sum -b */* > \"\${tmp}\" && mv -f \"\${tmp}\" SHA256SUMS; fi"
     ;;
   images)
     if in_container; then
@@ -316,9 +348,9 @@ case "$stage" in
       exit 2
     fi
     log_msg info "building build image: $BUILD_IMAGE"
-    docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.build" -t "$BUILD_IMAGE" "$ROOT"
+    run_with_timeout "$TIMEOUT_IMAGE_BUILD_SEC" docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.build" -t "$BUILD_IMAGE" "$ROOT"
     log_msg info "building dev image: $DEV_IMAGE"
-    docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
+    run_with_timeout "$TIMEOUT_IMAGE_BUILD_SEC" docker build "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
     ;;
   targets)
     run "$DEV_IMAGE" 'go tool dist list'
@@ -337,7 +369,7 @@ case "$stage" in
     fi
     # Use official WineBot entrypoint with explorer supervision disabled for CLI workloads
     log_msg info "running version check (WineBot E2E)"
-    docker run --rm \
+    run_with_timeout "$TIMEOUT_SMOKE_SEC" docker run --rm \
       -v "$(pwd)/$exe:/apps/supragoflow.exe" \
       -e APP_EXE=/apps/supragoflow.exe \
       -e APP_ARGS="--version --json" \
@@ -346,7 +378,7 @@ case "$stage" in
       "$WINE_IMAGE"
 
     log_msg info "running tls check (WineBot E2E)"
-    docker run --rm \
+    run_with_timeout "$TIMEOUT_SMOKE_SEC" docker run --rm \
       -v "$(pwd)/$exe:/apps/supragoflow.exe" \
       -e APP_EXE=/apps/supragoflow.exe \
       -e APP_ARGS="check-tls" \
@@ -355,7 +387,7 @@ case "$stage" in
       "$WINE_IMAGE"
 
     log_msg info "running ssh check (WineBot E2E)"
-    docker run --rm \
+    run_with_timeout "$TIMEOUT_SMOKE_SEC" docker run --rm \
       -v "$(pwd)/$exe:/apps/supragoflow.exe" \
       -e APP_EXE=/apps/supragoflow.exe \
       -e APP_ARGS="check-ssh" \


### PR DESCRIPTION
## Summary
Adds configurable bounds for runtime resource/time behavior and improves idempotence/atomicity in artifact generation.

### Implemented
- Add `gg` timeout controls:
  - `SUPRAGOFLOW_TIMEOUT_STAGE_SEC`
  - `SUPRAGOFLOW_TIMEOUT_PULL_SEC`
  - `SUPRAGOFLOW_TIMEOUT_IMAGE_BUILD_SEC`
  - `SUPRAGOFLOW_TIMEOUT_SMOKE_SEC`
- Add configurable pull retries/backoff:
  - `SUPRAGOFLOW_PULL_RETRIES`
  - `SUPRAGOFLOW_PULL_BACKOFF_SEC`
- Make build and package output writes atomic (temp file + rename).
- Add configurable SSH timeout API:
  - new `NewSSHClientConfigWithTimeout(...)`
  - existing `NewSSHClientConfig(...)` preserved via default timeout.
- Add explicit CI and release workflow job timeouts.

## Deferred tracking
- Refs #24 (SSH input size bounds for oversized material).
- Refs #21 (release tag immutability safeguards).

## Validation
- `./scripts/gg fmt`
- `./scripts/gg self-test`
- `./scripts/gg test`
- `./scripts/gg lint`
