### PR TITLE
Scale CI with artifact reuse and cache-aware gg runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,19 @@ jobs:
     timeout-minutes: 30
     env:
       GHCR_ORG: ${{ github.repository_owner }}
+      SUPRAGOFLOW_IMAGE_TAG: ${{ vars.SUPRAGOFLOW_IMAGE_TAG }}
+      SUPRAGOFLOW_CACHE_STRATEGY: host
     steps:
       - uses: actions/checkout@v4
+      - name: Restore Go build/module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .cache/supragoflow/gocache
+            .cache/supragoflow/gomodcache
+          key: gg-cache-${{ runner.os }}-${{ hashFiles('**/go.sum', '.versions', 'docker/Dockerfile.build', 'docker/Dockerfile.dev') }}
+          restore-keys: |
+            gg-cache-${{ runner.os }}-
 
       - name: Validate output template rendering
         run: ./scripts/test-output-template.sh
@@ -54,22 +65,44 @@ jobs:
       - name: Build windows amd64
         run: ./scripts/gg build windows amd64
 
+      - name: Upload windows artifact for smoke test
+        uses: actions/upload-artifact@v4
+        with:
+          name: supragoflow-windows-amd64
+          path: dist/windows-amd64/supragoflow.exe
+          if-no-files-found: error
+
   windows_wine_smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: gates
     env:
       GHCR_ORG: ${{ github.repository_owner }}
+      SUPRAGOFLOW_IMAGE_TAG: ${{ vars.SUPRAGOFLOW_IMAGE_TAG }}
+      SUPRAGOFLOW_CACHE_STRATEGY: host
       SUPRAGOFLOW_WINE_RUNNER_IMAGE: ${{ vars.SUPRAGOFLOW_WINE_RUNNER_IMAGE }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore Go build/module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .cache/supragoflow/gocache
+            .cache/supragoflow/gomodcache
+          key: gg-cache-${{ runner.os }}-${{ hashFiles('**/go.sum', '.versions', 'docker/Dockerfile.build', 'docker/Dockerfile.dev') }}
+          restore-keys: |
+            gg-cache-${{ runner.os }}-
 
       - name: Validate smoke runner image configuration
         run: |
           test -n "${SUPRAGOFLOW_WINE_RUNNER_IMAGE}" || (echo "Set repository variable SUPRAGOFLOW_WINE_RUNNER_IMAGE to a canonical Wine runner image." >&2; exit 2)
 
-      - name: Build windows amd64
-        run: ./scripts/gg build windows amd64
+      - name: Download windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: supragoflow-windows-amd64
+          path: dist/windows-amd64
 
       - name: Wine smoke test
         run: ./scripts/gg smoke-windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.cache/

--- a/POLICY.md
+++ b/POLICY.md
@@ -46,6 +46,7 @@ Typical gates for incremental development:
 - Informational diagnostics should be bounded; avoid repeating non-actionable messages across stages.
 - Timeouts and pull retry/backoff are configurable to bound long-running operations (`SUPRAGOFLOW_TIMEOUT_*`, `SUPRAGOFLOW_PULL_RETRIES`, `SUPRAGOFLOW_PULL_BACKOFF_SEC`).
 - Long-running operations provide liveness/progress feedback with configurable heartbeat interval (`SUPRAGOFLOW_HEARTBEAT_SEC`).
+- Cache strategy is configurable (`SUPRAGOFLOW_CACHE_STRATEGY=volume|host`); CI should prefer `host` to enable cache restore/save across runs.
 
 ## Builds (build image)
 
@@ -80,6 +81,7 @@ Typical gates for incremental development:
 - Release workflows publish explicit release tags only; `:latest` is not part of the canonical path.
 - Users/agents should prefer GHCR release tags over local images.
 - `scripts/gg` only attempts remote pulls when `SUPRAGOFLOW_IMAGE_TAG` is set.
+- CI may set repository variable `SUPRAGOFLOW_IMAGE_TAG` to a canonical release tag to enable pull-first image reuse before local fallback build.
 - `gg smoke-windows` requires an explicit runner image via `SUPRAGOFLOW_WINE_RUNNER_IMAGE`.
 
 ## Service discoverability

--- a/README.md
+++ b/README.md
@@ -91,8 +91,12 @@ When `--log-format json` is used, logs include `logSchemaVersion` and `run_id` f
 Runtime bounds are configurable with env vars, including:
 `SUPRAGOFLOW_TIMEOUT_STAGE_SEC`, `SUPRAGOFLOW_TIMEOUT_PULL_SEC`, `SUPRAGOFLOW_TIMEOUT_IMAGE_BUILD_SEC`, `SUPRAGOFLOW_TIMEOUT_SMOKE_SEC`, `SUPRAGOFLOW_PULL_RETRIES`, `SUPRAGOFLOW_PULL_BACKOFF_SEC`.
 Liveness heartbeat interval for long operations is configurable via `SUPRAGOFLOW_HEARTBEAT_SEC` (set `0` to disable periodic in-progress logs).
+Cache behavior is configurable via `SUPRAGOFLOW_CACHE_STRATEGY`:
+- `volume` (default): Docker named volumes for local iterative runs
+- `host`: bind mounts under `SUPRAGOFLOW_HOST_CACHE_ROOT` (default `.cache/supragoflow`) for CI cache restore/save compatibility
 
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
+To enable pull-first CI image reuse from GHCR release images, set repository variable `SUPRAGOFLOW_IMAGE_TAG` to a canonical release tag.
 
 `build` supports semantic artifact naming templates with tokens: `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.
 For reproducible metadata, `SUPRAGOFLOW_BUILD_DATE` can be set to a fixed RFC3339 UTC timestamp used for embedded build date.

--- a/scripts/gg
+++ b/scripts/gg
@@ -47,6 +47,8 @@ fi
 # Named volumes for speed (safe for humans/agents)
 MODVOL="${SUPRAGOFLOW_MODVOL:-supragoflow-gomodcache}"
 CACHEVOL="${SUPRAGOFLOW_CACHEVOL:-supragoflow-gocache}"
+CACHE_STRATEGY="${SUPRAGOFLOW_CACHE_STRATEGY:-volume}"
+HOST_CACHE_ROOT="${SUPRAGOFLOW_HOST_CACHE_ROOT:-${ROOT}/.cache/supragoflow}"
 
 run_with_timeout() {
   local timeout_sec="$1"; shift
@@ -149,7 +151,26 @@ ensure_images() {
 
 run_in_image() {
   local image="$1"; shift
-  run_with_timeout "$TIMEOUT_STAGE_SEC" "docker run ${image}" docker run --rm -t     -v "${ROOT}:${WORKDIR}" -w "${WORKDIR}"     -v "${CACHEVOL}:/go-cache"     -v "${MODVOL}:/go/pkg/mod"     -e GOCACHE=/go-cache     -e GOMODCACHE=/go/pkg/mod     -e GOPATH=/go     "$image" bash -c "$*"
+  if [[ "$CACHE_STRATEGY" == "host" ]]; then
+    mkdir -p "${HOST_CACHE_ROOT}/gocache" "${HOST_CACHE_ROOT}/gomodcache"
+    run_with_timeout "$TIMEOUT_STAGE_SEC" "docker run ${image}" docker run --rm -t \
+      -v "${ROOT}:${WORKDIR}" -w "${WORKDIR}" \
+      -v "${HOST_CACHE_ROOT}/gocache:/go-cache" \
+      -v "${HOST_CACHE_ROOT}/gomodcache:/go/pkg/mod" \
+      -e GOCACHE=/go-cache \
+      -e GOMODCACHE=/go/pkg/mod \
+      -e GOPATH=/go \
+      "$image" bash -c "$*"
+  else
+    run_with_timeout "$TIMEOUT_STAGE_SEC" "docker run ${image}" docker run --rm -t \
+      -v "${ROOT}:${WORKDIR}" -w "${WORKDIR}" \
+      -v "${CACHEVOL}:/go-cache" \
+      -v "${MODVOL}:/go/pkg/mod" \
+      -e GOCACHE=/go-cache \
+      -e GOMODCACHE=/go/pkg/mod \
+      -e GOPATH=/go \
+      "$image" bash -c "$*"
+  fi
 }
 
 run() {


### PR DESCRIPTION
## Summary
- remove duplicate windows build by reusing the built artifact between CI jobs
- add CI cache restore/save for Go build/module caches using host cache strategy in `gg`
- wire optional pull-first GHCR behavior in CI via `SUPRAGOFLOW_IMAGE_TAG` repo variable
- document cache strategy and CI image-tag policy in README/POLICY

## Validation
- bash -n scripts/gg
- ./scripts/gg self-test
- ./scripts/gg lint
- ./scripts/gg test
- ./scripts/gg build windows amd64

## Deferred backlog tracking
- #27 reusable SSH host key callback path for high-throughput callers
- #28 release image publish matrix parallelization
