### PR TITLE
Tier CI gates and bound host cache growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     env:
       GHCR_ORG: ${{ github.repository_owner }}
       SUPRAGOFLOW_IMAGE_TAG: ${{ vars.SUPRAGOFLOW_IMAGE_TAG }}
+      SUPRAGOFLOW_BUILD_IMAGE_REF: ${{ vars.SUPRAGOFLOW_BUILD_IMAGE_REF }}
+      SUPRAGOFLOW_DEV_IMAGE_REF: ${{ vars.SUPRAGOFLOW_DEV_IMAGE_REF }}
       SUPRAGOFLOW_CACHE_STRATEGY: host
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +55,8 @@ jobs:
       - name: Lint
         run: ./scripts/gg lint
 
-      - name: Vulnerability check
+      - name: Vulnerability check (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: ./scripts/gg vuln
 
       - name: Test
@@ -62,23 +65,32 @@ jobs:
       - name: Build linux amd64
         run: ./scripts/gg build linux amd64
 
-      - name: Build windows amd64
+      - name: Build windows amd64 (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: ./scripts/gg build windows amd64
 
-      - name: Upload windows artifact for smoke test
+      - name: Upload windows artifact for smoke test (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: supragoflow-windows-amd64
           path: dist/windows-amd64/supragoflow.exe
           if-no-files-found: error
 
+      - name: Prune host cache to configured limit
+        if: always()
+        run: ./scripts/gg cache-prune
+
   windows_wine_smoke:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: gates
     env:
       GHCR_ORG: ${{ github.repository_owner }}
       SUPRAGOFLOW_IMAGE_TAG: ${{ vars.SUPRAGOFLOW_IMAGE_TAG }}
+      SUPRAGOFLOW_BUILD_IMAGE_REF: ${{ vars.SUPRAGOFLOW_BUILD_IMAGE_REF }}
+      SUPRAGOFLOW_DEV_IMAGE_REF: ${{ vars.SUPRAGOFLOW_DEV_IMAGE_REF }}
       SUPRAGOFLOW_CACHE_STRATEGY: host
       SUPRAGOFLOW_WINE_RUNNER_IMAGE: ${{ vars.SUPRAGOFLOW_WINE_RUNNER_IMAGE }}
     steps:
@@ -106,3 +118,7 @@ jobs:
 
       - name: Wine smoke test
         run: ./scripts/gg smoke-windows
+
+      - name: Prune host cache to configured limit
+        if: always()
+        run: ./scripts/gg cache-prune

--- a/POLICY.md
+++ b/POLICY.md
@@ -47,6 +47,7 @@ Typical gates for incremental development:
 - Timeouts and pull retry/backoff are configurable to bound long-running operations (`SUPRAGOFLOW_TIMEOUT_*`, `SUPRAGOFLOW_PULL_RETRIES`, `SUPRAGOFLOW_PULL_BACKOFF_SEC`).
 - Long-running operations provide liveness/progress feedback with configurable heartbeat interval (`SUPRAGOFLOW_HEARTBEAT_SEC`).
 - Cache strategy is configurable (`SUPRAGOFLOW_CACHE_STRATEGY=volume|host`); CI should prefer `host` to enable cache restore/save across runs.
+- Host cache should be size-bounded in automation (`SUPRAGOFLOW_HOST_CACHE_MAX_MB`) and pruned with `gg cache-prune`.
 
 ## Builds (build image)
 
@@ -80,9 +81,16 @@ Typical gates for incremental development:
 - Container images are built and pushed to GHCR **only** on GitHub Release (`release.published`).
 - Release workflows publish explicit release tags only; `:latest` is not part of the canonical path.
 - Users/agents should prefer GHCR release tags over local images.
-- `scripts/gg` only attempts remote pulls when `SUPRAGOFLOW_IMAGE_TAG` is set.
+- `scripts/gg` supports pull-first image reuse via explicit refs:
+  - Preferred: `SUPRAGOFLOW_BUILD_IMAGE_REF` and `SUPRAGOFLOW_DEV_IMAGE_REF` (digest pinning supported).
+  - Fallback: `SUPRAGOFLOW_IMAGE_TAG`.
 - CI may set repository variable `SUPRAGOFLOW_IMAGE_TAG` to a canonical release tag to enable pull-first image reuse before local fallback build.
 - `gg smoke-windows` requires an explicit runner image via `SUPRAGOFLOW_WINE_RUNNER_IMAGE`.
+
+## CI tiering
+
+- Pull requests run a fast gate by default (format/vet/lint/test/linux build).
+- Full gate (including vulnerability scan and Wine-based Windows smoke) runs on `main` pushes.
 
 ## Service discoverability
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ Liveness heartbeat interval for long operations is configurable via `SUPRAGOFLOW
 Cache behavior is configurable via `SUPRAGOFLOW_CACHE_STRATEGY`:
 - `volume` (default): Docker named volumes for local iterative runs
 - `host`: bind mounts under `SUPRAGOFLOW_HOST_CACHE_ROOT` (default `.cache/supragoflow`) for CI cache restore/save compatibility
+Host cache can be bounded with `SUPRAGOFLOW_HOST_CACHE_MAX_MB` and pruned via `./scripts/gg cache-prune`.
 
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
-To enable pull-first CI image reuse from GHCR release images, set repository variable `SUPRAGOFLOW_IMAGE_TAG` to a canonical release tag.
+To enable pull-first CI image reuse from GHCR release images, set one of:
+- `SUPRAGOFLOW_BUILD_IMAGE_REF` / `SUPRAGOFLOW_DEV_IMAGE_REF` (preferred; supports digest-pinned refs)
+- `SUPRAGOFLOW_IMAGE_TAG` (tag-based fallback)
 
 `build` supports semantic artifact naming templates with tokens: `{name}`, `{version}`, `{os}`, `{arch}`, `{ext}`.
 For reproducible metadata, `SUPRAGOFLOW_BUILD_DATE` can be set to a fixed RFC3339 UTC timestamp used for embedded build date.

--- a/scripts/gg
+++ b/scripts/gg
@@ -36,6 +36,8 @@ BUILD_ARGS=(
 DEV_IMAGE="${SUPRAGOFLOW_DEV_IMAGE:-supragoflow-dev:local}"
 BUILD_IMAGE="${SUPRAGOFLOW_BUILD_IMAGE:-supragoflow-build:local}"
 IMAGE_TAG="${SUPRAGOFLOW_IMAGE_TAG:-}"
+BUILD_IMAGE_REF="${SUPRAGOFLOW_BUILD_IMAGE_REF:-}"
+DEV_IMAGE_REF="${SUPRAGOFLOW_DEV_IMAGE_REF:-}"
 WINE_IMAGE="${SUPRAGOFLOW_WINE_RUNNER_IMAGE:-}"
 DEFAULT_OUTPUT_TEMPLATE="${SUPRAGOFLOW_OUTPUT_TEMPLATE:-}"
 DEFAULT_BUILD_VERSION="${SUPRAGOFLOW_BUILD_VERSION:-dev-local}"
@@ -286,21 +288,27 @@ image_exists() {
 pull_images() {
   local org="${GHCR_ORG:-SemperSupra}"
   local tag="${IMAGE_TAG}"
+  local build_remote="${BUILD_IMAGE_REF}"
+  local dev_remote="${DEV_IMAGE_REF}"
   # convert org to lowercase
   org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
 
-  if [[ -z "$tag" ]]; then
+  if [[ -z "$build_remote" && -z "$dev_remote" && -z "$tag" ]]; then
     if [[ "$REMOTE_PULL_DISABLED_NOTIFIED" -eq 0 ]]; then
-      log_msg debug "remote image pull disabled (set SUPRAGOFLOW_IMAGE_TAG to a release tag to enable)"
+      log_msg debug "remote image pull disabled (set SUPRAGOFLOW_BUILD_IMAGE_REF/SUPRAGOFLOW_DEV_IMAGE_REF or SUPRAGOFLOW_IMAGE_TAG)"
       REMOTE_PULL_DISABLED_NOTIFIED=1
     fi
     return
   fi
 
-  local build_remote="ghcr.io/$org/supragoflow-build:$tag"
-  local dev_remote="ghcr.io/$org/supragoflow-dev:$tag"
+  if [[ -z "$build_remote" && -n "$tag" ]]; then
+    build_remote="ghcr.io/$org/supragoflow-build:$tag"
+  fi
+  if [[ -z "$dev_remote" && -n "$tag" ]]; then
+    dev_remote="ghcr.io/$org/supragoflow-dev:$tag"
+  fi
 
-  if ! image_exists "$BUILD_IMAGE"; then
+  if [[ -n "$build_remote" ]] && ! image_exists "$BUILD_IMAGE"; then
     if docker_pull_with_retry "$build_remote"; then
       log_msg info "pulled build image from $build_remote"
       docker tag "$build_remote" "$BUILD_IMAGE"
@@ -309,7 +317,7 @@ pull_images() {
     fi
   fi
 
-  if ! image_exists "$DEV_IMAGE"; then
+  if [[ -n "$dev_remote" ]] && ! image_exists "$DEV_IMAGE"; then
     if docker_pull_with_retry "$dev_remote"; then
       log_msg info "pulled dev image from $dev_remote"
       docker tag "$dev_remote" "$DEV_IMAGE"
@@ -450,6 +458,28 @@ case "$stage" in
     log_msg info "building dev image: $DEV_IMAGE"
     docker_build_with_verbosity "$TIMEOUT_IMAGE_BUILD_SEC" "docker build ${DEV_IMAGE}" "${BUILD_ARGS[@]}" -f "${ROOT}/docker/Dockerfile.dev" -t "$DEV_IMAGE" "$ROOT"
     ;;
+  cache-prune)
+    if [[ "$CACHE_STRATEGY" != "host" ]]; then
+      log_msg info "cache-prune skipped (SUPRAGOFLOW_CACHE_STRATEGY=${CACHE_STRATEGY}; host required)"
+      exit 0
+    fi
+    max_mb="${SUPRAGOFLOW_HOST_CACHE_MAX_MB:-2048}"
+    if ! [[ "$max_mb" =~ ^[0-9]+$ ]] || [[ "$max_mb" -le 0 ]]; then
+      echo "SUPRAGOFLOW_HOST_CACHE_MAX_MB must be a positive integer" >&2
+      exit 2
+    fi
+    mkdir -p "${HOST_CACHE_ROOT}/gocache" "${HOST_CACHE_ROOT}/gomodcache"
+    size_kb="$(du -sk "${HOST_CACHE_ROOT}" | awk '{print $1}')"
+    max_kb=$((max_mb * 1024))
+    if (( size_kb > max_kb )); then
+      log_msg warn "pruning host cache at ${HOST_CACHE_ROOT} size=${size_kb}KB limit=${max_kb}KB"
+      rm -rf "${HOST_CACHE_ROOT}/gocache" "${HOST_CACHE_ROOT}/gomodcache"
+      mkdir -p "${HOST_CACHE_ROOT}/gocache" "${HOST_CACHE_ROOT}/gomodcache"
+      log_msg info "host cache prune completed"
+    else
+      log_msg info "host cache within limit size=${size_kb}KB limit=${max_kb}KB"
+    fi
+    ;;
   targets)
     run "$DEV_IMAGE" 'go tool dist list'
     ;;
@@ -516,6 +546,7 @@ stages:
   build <goos> <goarch> [--output-template <template>] [--print-output-name]
   package
   images   (build local images on host)
+  cache-prune (prune host cache when above SUPRAGOFLOW_HOST_CACHE_MAX_MB)
   smoke-windows [goarch]
 
 build output template tokens:


### PR DESCRIPTION
## Summary
- tier CI behavior: fast PR gate and full gate on `main` push
- keep `gates` job name stable while conditionally running vuln/windows steps only on `main`
- run `windows_wine_smoke` only on `main` pushes
- add host cache bounding via new `gg cache-prune` stage
- support digest-pinned pull-first GHCR refs via `SUPRAGOFLOW_BUILD_IMAGE_REF` / `SUPRAGOFLOW_DEV_IMAGE_REF` (with tag fallback)
- update README/POLICY for tiering, cache bounds, and image ref policy

## Deferred issues created
- #30 path-aware vuln scan trigger for PRs
- #31 re-evaluate Windows smoke cadence policy

## Validation
- bash -n scripts/gg
- ./scripts/gg self-test
- SUPRAGOFLOW_CACHE_STRATEGY=host SUPRAGOFLOW_HOST_CACHE_MAX_MB=2048 ./scripts/gg cache-prune
- ./scripts/gg lint
- ./scripts/gg test
