### PR TITLE
Expand test assurance and add bounded diagnostics

### DIFF
--- a/POLICY.md
+++ b/POLICY.md
@@ -48,6 +48,7 @@ Typical gates for incremental development:
 - Long-running operations provide liveness/progress feedback with configurable heartbeat interval (`SUPRAGOFLOW_HEARTBEAT_SEC`).
 - Cache strategy is configurable (`SUPRAGOFLOW_CACHE_STRATEGY=volume|host`); CI should prefer `host` to enable cache restore/save across runs.
 - Host cache should be size-bounded in automation (`SUPRAGOFLOW_HOST_CACHE_MAX_MB`) and pruned with `gg cache-prune`.
+- `gg diagnose` should produce bounded diagnostics bundles suitable for corrective maintenance and CI triage.
 
 ## Builds (build image)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `./scripts/gg` entrypoint supports the following stages:
 | `package` | Package artifacts (create checksums) |
 | `images` | Build local Docker images |
 | `cache-prune` | Prune host cache when above configured limit |
+| `diagnose [out_dir]` | Generate bounded diagnostics bundle and compressed archive |
 | `smoke-windows [goarch]` | Run Windows binary in Wine (default: amd64) |
 
 Global `gg` logging options (place before stage): `--log-level <debug|info|warn|error|none>`, `--log-format <text|json>`, `--run-id <id>`.
@@ -96,6 +97,7 @@ Cache behavior is configurable via `SUPRAGOFLOW_CACHE_STRATEGY`:
 - `volume` (default): Docker named volumes for local iterative runs
 - `host`: bind mounts under `SUPRAGOFLOW_HOST_CACHE_ROOT` (default `.cache/supragoflow`) for CI cache restore/save compatibility
 Host cache can be bounded with `SUPRAGOFLOW_HOST_CACHE_MAX_MB` and pruned via `./scripts/gg cache-prune`.
+For failure analysis, `./scripts/gg diagnose` writes a bounded diagnostics bundle under `dist/diagnostics/`.
 
 `smoke-windows` requires `SUPRAGOFLOW_WINE_RUNNER_IMAGE` to be set explicitly.
 To enable pull-first CI image reuse from GHCR release images, set one of:

--- a/cmd/supragoflow/main_test.go
+++ b/cmd/supragoflow/main_test.go
@@ -7,6 +7,75 @@ import (
 	"testing"
 )
 
+func TestRunCapabilitySetTable(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		wantSubstrs []string
+	}{
+		{
+			name:        "usage",
+			args:        nil,
+			wantErr:     false,
+			wantSubstrs: []string{"usage: supragoflow", "subcommands:"},
+		},
+		{
+			name:        "version subcommand",
+			args:        []string{"version"},
+			wantErr:     false,
+			wantSubstrs: []string{"version=", "commit=", "date=", "builtBy="},
+		},
+		{
+			name:        "legacy version flag",
+			args:        []string{"--version"},
+			wantErr:     false,
+			wantSubstrs: []string{"version=", "commit=", "date=", "builtBy="},
+		},
+		{
+			name:        "check tls",
+			args:        []string{"check-tls"},
+			wantErr:     false,
+			wantSubstrs: []string{"Checking TLS configuration builder...", "OK: TLS client config builder initialized successfully."},
+		},
+		{
+			name:        "check ssh",
+			args:        []string{"check-ssh"},
+			wantErr:     false,
+			wantSubstrs: []string{"Checking SSH configuration builder...", "OK: SSH client config builder initialized successfully."},
+		},
+		{
+			name:        "unknown subcommand",
+			args:        []string{"nope"},
+			wantErr:     true,
+			wantSubstrs: []string{"unknown subcommand"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := run(tc.args, &out)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("wantErr=%v got err=%v", tc.wantErr, err)
+			}
+
+			gotText := out.String()
+			for _, want := range tc.wantSubstrs {
+				if tc.wantErr {
+					if err == nil || !strings.Contains(err.Error(), want) {
+						t.Fatalf("expected error containing %q, got %v", want, err)
+					}
+					continue
+				}
+				if !strings.Contains(gotText, want) {
+					t.Fatalf("expected output to contain %q, got %q", want, gotText)
+				}
+			}
+		})
+	}
+}
+
 func TestRunDefaultOutput(t *testing.T) {
 	var out bytes.Buffer
 	if err := run(nil, &out); err != nil {
@@ -94,6 +163,9 @@ func TestRunVersionJSON(t *testing.T) {
 		if _, ok := payload[key]; !ok {
 			t.Fatalf("missing key %q in JSON output: %v", key, payload)
 		}
+	}
+	if len(payload) != 5 {
+		t.Fatalf("unexpected key count in JSON output: %v", payload)
 	}
 	if payload["schemaVersion"] != "1" {
 		t.Fatalf("unexpected schemaVersion %q", payload["schemaVersion"])

--- a/internal/securecomms/ssh_test.go
+++ b/internal/securecomms/ssh_test.go
@@ -138,6 +138,41 @@ func TestNewSSHClientConfigInvalidInput(t *testing.T) {
 	}
 }
 
+func TestSSHHostKeyCallbackRejectsMismatchedHostKey(t *testing.T) {
+	clientKeyPEM, err := generateRSAPrivateKeyPEM()
+	if err != nil {
+		t.Fatalf("generateRSAPrivateKeyPEM: %v", err)
+	}
+	knownHostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey known host: %v", err)
+	}
+	knownSigner, err := ssh.NewSignerFromKey(knownHostKey)
+	if err != nil {
+		t.Fatalf("ssh.NewSignerFromKey known host: %v", err)
+	}
+	knownHostsLine := knownhosts.Line([]string{"example.com"}, knownSigner.PublicKey())
+
+	cfg, err := NewSSHClientConfig("alice", clientKeyPEM, []byte(knownHostsLine+"\n"))
+	if err != nil {
+		t.Fatalf("NewSSHClientConfig: %v", err)
+	}
+
+	otherHostKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey other host: %v", err)
+	}
+	otherSigner, err := ssh.NewSignerFromKey(otherHostKey)
+	if err != nil {
+		t.Fatalf("ssh.NewSignerFromKey other host: %v", err)
+	}
+
+	err = cfg.HostKeyCallback("example.com:22", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 22}, otherSigner.PublicKey())
+	if err == nil {
+		t.Fatal("expected host key callback failure for mismatched host key")
+	}
+}
+
 func generateRSAPrivateKeyPEM() ([]byte, error) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/internal/securecomms/tls_test.go
+++ b/internal/securecomms/tls_test.go
@@ -102,6 +102,157 @@ func TestNewTLSServerConfigInvalidInput(t *testing.T) {
 	}
 }
 
+func TestTLSHandshakeBehavior(t *testing.T) {
+	caPEM, caCert, caKey, err := generateCA(t)
+	if err != nil {
+		t.Fatalf("generateCA: %v", err)
+	}
+
+	serverCertPEM, serverKeyPEM, err := generateLeafCert(t, caCert, caKey, "server.example")
+	if err != nil {
+		t.Fatalf("generateLeafCert: %v", err)
+	}
+	serverCfg, err := NewTLSServerConfig(serverCertPEM, serverKeyPEM, nil, false)
+	if err != nil {
+		t.Fatalf("NewTLSServerConfig: %v", err)
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := conn.(*tls.Conn)
+		_ = tlsConn.SetDeadline(time.Now().Add(3 * time.Second))
+		_ = tlsConn.Handshake()
+		_, _ = tlsConn.Write([]byte("ok"))
+		_ = conn.Close()
+	}()
+
+	clientCfg, err := NewTLSClientConfig(caPEM, "server.example", nil, nil, false)
+	if err != nil {
+		t.Fatalf("NewTLSClientConfig: %v", err)
+	}
+	clientConn, err := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial should succeed: %v", err)
+	}
+	_ = clientConn.Close()
+	<-done
+
+	ln2, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen second: %v", err)
+	}
+	defer func() { _ = ln2.Close() }()
+	go func() {
+		conn, err := ln2.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := conn.(*tls.Conn)
+		_ = tlsConn.SetDeadline(time.Now().Add(3 * time.Second))
+		_ = tlsConn.Handshake()
+		_ = tlsConn.Close()
+	}()
+
+	badClientCfg, err := NewTLSClientConfig(caPEM, "wrong.example", nil, nil, false)
+	if err != nil {
+		t.Fatalf("NewTLSClientConfig bad host: %v", err)
+	}
+	badConn, err := tls.Dial("tcp", ln2.Addr().String(), badClientCfg)
+	if err == nil {
+		_ = badConn.Close()
+		t.Fatal("expected tls.Dial to fail for wrong ServerName")
+	}
+}
+
+func TestTLSMutualTLSHandshakeBehavior(t *testing.T) {
+	caPEM, caCert, caKey, err := generateCA(t)
+	if err != nil {
+		t.Fatalf("generateCA: %v", err)
+	}
+	serverCertPEM, serverKeyPEM, err := generateLeafCert(t, caCert, caKey, "mtls.example")
+	if err != nil {
+		t.Fatalf("generateLeafCert server: %v", err)
+	}
+	clientCertPEM, clientKeyPEM, err := generateLeafCert(t, caCert, caKey, "client.example")
+	if err != nil {
+		t.Fatalf("generateLeafCert client: %v", err)
+	}
+
+	serverCfg, err := NewTLSServerConfig(serverCertPEM, serverKeyPEM, caPEM, true)
+	if err != nil {
+		t.Fatalf("NewTLSServerConfig: %v", err)
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := conn.(*tls.Conn)
+		_ = tlsConn.SetDeadline(time.Now().Add(3 * time.Second))
+		_ = tlsConn.Handshake()
+		_ = tlsConn.Close()
+	}()
+
+	clientCfg, err := NewTLSClientConfig(caPEM, "mtls.example", clientCertPEM, clientKeyPEM, false)
+	if err != nil {
+		t.Fatalf("NewTLSClientConfig: %v", err)
+	}
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("expected mTLS handshake success: %v", err)
+	}
+	_ = conn.Close()
+
+	// New listener for missing client cert negative path.
+	ln2, err := tls.Listen("tcp", "127.0.0.1:0", serverCfg)
+	if err != nil {
+		t.Fatalf("tls.Listen second: %v", err)
+	}
+	defer func() { _ = ln2.Close() }()
+	handshakeErrCh := make(chan error, 1)
+	go func() {
+		conn, err := ln2.Accept()
+		if err != nil {
+			handshakeErrCh <- err
+			return
+		}
+		tlsConn := conn.(*tls.Conn)
+		_ = tlsConn.SetDeadline(time.Now().Add(3 * time.Second))
+		handshakeErrCh <- tlsConn.Handshake()
+		_ = tlsConn.Close()
+	}()
+
+	noClientCertCfg, err := NewTLSClientConfig(caPEM, "mtls.example", nil, nil, false)
+	if err != nil {
+		t.Fatalf("NewTLSClientConfig no cert: %v", err)
+	}
+	conn2, err := tls.Dial("tcp", ln2.Addr().String(), noClientCertCfg)
+	if err == nil {
+		_ = conn2.Close()
+	}
+	serverErr := <-handshakeErrCh
+	if serverErr == nil {
+		t.Fatal("expected server-side mTLS handshake failure when client cert missing")
+	}
+}
+
 func generateCA(t *testing.T) ([]byte, *x509.Certificate, *rsa.PrivateKey, error) {
 	t.Helper()
 

--- a/scripts/gg
+++ b/scripts/gg
@@ -480,6 +480,40 @@ case "$stage" in
       log_msg info "host cache within limit size=${size_kb}KB limit=${max_kb}KB"
     fi
     ;;
+  diagnose)
+    out_dir="${1:-dist/diagnostics/${RUN_ID}}"
+    if ! mkdir -p "${out_dir}" 2>/dev/null; then
+      fallback_dir="/tmp/supragoflow-diagnostics/${RUN_ID}"
+      log_msg warn "diagnose output path not writable: ${out_dir}; using ${fallback_dir}"
+      out_dir="${fallback_dir}"
+      mkdir -p "${out_dir}"
+    fi
+
+    {
+      echo "run_id=${RUN_ID}"
+      echo "generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      echo "root=${ROOT}"
+      echo "log_level=${LOG_LEVEL}"
+      echo "log_format=${LOG_FORMAT}"
+      echo "cache_strategy=${CACHE_STRATEGY}"
+    } > "${out_dir}/summary.txt"
+
+    (env | grep -E '^(SUPRAGOFLOW_|GHCR_|GITHUB_)' | sort) > "${out_dir}/env.txt" 2>/dev/null || true
+    (git -C "${ROOT}" status -sb) > "${out_dir}/git-status.txt" 2>/dev/null || true
+    (git -C "${ROOT}" log --oneline -n 10) > "${out_dir}/git-log.txt" 2>/dev/null || true
+    (cat "${ROOT}/.versions") > "${out_dir}/toolchain-versions.txt" 2>/dev/null || true
+    (du -sh "${ROOT}/dist" "${HOST_CACHE_ROOT}" 2>/dev/null || true) > "${out_dir}/sizes.txt" 2>/dev/null || true
+    (./scripts/gg --log-level error --log-format text self-test) > "${out_dir}/self-test.txt" 2>&1 || true
+
+    if command -v docker >/dev/null 2>&1; then
+      run_with_timeout 20 "diagnose docker images" docker image ls > "${out_dir}/docker-images.txt" 2>&1 || true
+      run_with_timeout 20 "diagnose docker system df" docker system df > "${out_dir}/docker-system-df.txt" 2>&1 || true
+    fi
+
+    tarball="${out_dir}.tar.gz"
+    tar -czf "${tarball}" -C "$(dirname "${out_dir}")" "$(basename "${out_dir}")"
+    log_msg info "diagnostics bundle written: ${tarball}"
+    ;;
   targets)
     run "$DEV_IMAGE" 'go tool dist list'
     ;;
@@ -547,6 +581,7 @@ stages:
   package
   images   (build local images on host)
   cache-prune (prune host cache when above SUPRAGOFLOW_HOST_CACHE_MAX_MB)
+  diagnose [out_dir] (write bounded diagnostics bundle and .tar.gz)
   smoke-windows [goarch]
 
 build output template tokens:


### PR DESCRIPTION
## Summary
- add table-driven CLI capability-set tests in `cmd/supragoflow`
- strengthen machine-output contract test for `--version --json`
- add deeper secure-comms behavioral tests:
  - TLS handshake success/failure (hostname mismatch)
  - mTLS positive and negative server-side handshake assertions
  - SSH host-key callback mismatch rejection
- add `gg diagnose` stage to generate bounded diagnostics bundles (+ tar.gz)
- add writable-path fallback for diagnostics when default `dist` path is not writable
- document diagnostics stage in README and policy

## Deferred tracking issues
- #37 fault-injection tests for gg bounds/timeouts/retries
- #38 optional trace mode for lifecycle actions

## Validation
- bash -n scripts/gg
- ./scripts/gg self-test
- ./scripts/gg lint
- ./scripts/gg test
- ./scripts/gg diagnose
